### PR TITLE
moved 'interactables' to server category

### DIFF
--- a/docs/making-mods/scripting/api.md
+++ b/docs/making-mods/scripting/api.md
@@ -483,6 +483,45 @@ end)
 
 ```
 
+### interactables
+
+```lua
+-- the game has interactable items such as ammo refills, doors, light switches and weapons (wip)
+-- you can override their behavior or create new ones here
+
+local CustomInteractable = {}
+CustomInteractable.__index = CustomInteractable
+
+function CustomInteractable.new(instance)
+	local self = {
+		players_killed = 0,
+		instance = instance,
+	}
+
+	return setmetatable(self, CustomInteractable)
+end
+
+function CustomInteractable:interact(player)
+	self.players_killed += 1
+	player.explode()
+	player.kill()
+	chat.send_announcement(`{self.players_killed} players killed total`)
+end
+
+-- replaces all ammo refill interactables in usual maps with this custom logic
+-- doors use "door"
+register_interactable("ammo_refill", CustomInteractable)
+register_interactable("capture_refill", CustomInteractable)
+
+-- any model that has an Attachment instance named display_point, and an attribute called
+-- "interactable_type" set to "part_killer" will have a pop up UI show that runs this code
+-- when interacted with
+register_interactable("part_killer", CustomInteractable)
+
+-- the map has to be reloaded before they work
+map.set_map("misc_shooting_range")
+```
+
 ## Client globals
 
 ### general
@@ -568,45 +607,6 @@ table.insert(config.settings_layout.controls, { setting = "toggle_godmode", type
 framework.character.is_alive() -- gets whether you're alive
 framework.character.get_position() -- returns character position
 framework.character.get_camera_cframe() -- gets the camera cframe
-```
-
-### interactables
-
-```lua
--- the game has interactable items such as ammo refills, doors, light switches and weapons (wip)
--- you can override their behavior or create new ones here
-
-local CustomInteractable = {}
-CustomInteractable.__index = CustomInteractable
-
-function CustomInteractable.new(instance)
-	local self = {
-		players_killed = 0,
-		instance = instance,
-	}
-
-	return setmetatable(self, CustomInteractable)
-end
-
-function CustomInteractable:interact(player)
-	self.players_killed += 1
-	player.explode()
-	player.kill()
-	chat.send_announcement(`{self.players_killed} players killed total`)
-end
-
--- replaces all ammo refill interactables in usual maps with this custom logic
--- doors use "door"
-register_interactable("ammo_refill", CustomInteractable)
-register_interactable("capture_refill", CustomInteractable)
-
--- any model that has an Attachment instance named display_point, and an attribute called
--- "interactable_type" set to "part_killer" will have a pop up UI show that runs this code
--- when interacted with
-register_interactable("part_killer", CustomInteractable)
-
--- the map has to be reloaded before they work
-map.set_map("misc_shooting_range")
 ```
 
 ### camera control


### PR DESCRIPTION
custom interactables can only be created by the server, as "register_interactable" is not a recognized function on the client